### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,10 +39,9 @@ class ItemsController < ApplicationController
       @item.destroy
       redirect_to root_path
     else
-      redirect_to item_path, method: :get 
+      redirect_to item_path, method: :get
     end
   end
-
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to item_path, method: :get unless @item.user_id == current_user.id
+    redirect_to item_path unless @item.user_id == current_user.id
   end
 
   def update
@@ -39,7 +39,7 @@ class ItemsController < ApplicationController
       @item.destroy
       redirect_to root_path
     else
-      redirect_to item_path, method: :get
+      redirect_to item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -33,6 +33,16 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to item_path, method: :get 
+    end
+  end
+
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
     <% else %>
     <% if user_signed_in? && @orders.blank? %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# What
- 出品者が商品を削除して、出品を取り消す機能
- 出品者以外は、商品の削除を実行できないように設定している

# Why
- 出品した商品を出品者が取り消したい場合に必要な機能である
- 商品に傷がついた・手放すのが嫌になったなど理由はいろいろ考えられるが必要と考える

# 商品削除機能　動画
- 出品者ならば削除できる
- https://gyazo.com/65aae020223545d807f6046f02b613cd

- 出品者以外は削除できない（削除ボタンが表示されない）
- https://gyazo.com/7741eb32917b77aaab92d17c0e11cc22
